### PR TITLE
DS-3047: Bug fixes, additional data pre+post-processing for Imputation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipImputation
 Type: Package
 Title: Data frame imputation
-Version: 1.0.1
+Version: 1.0.5
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Functions for imputing data using mice and hot.deck.
@@ -16,4 +16,4 @@ Suggests:
     testthat
 Remotes:
     Displayr/flipU
-RoxygenNote: 6.1.0
+RoxygenNote: 7.1.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipImputation
 Type: Package
 Title: Data frame imputation
-Version: 1.0.0
+Version: 1.0.1
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Functions for imputing data using mice and hot.deck.

--- a/R/imputation.R
+++ b/R/imputation.R
@@ -48,13 +48,15 @@ Imputation <- function(data = NULL, formula = NULL, method = "try mice", m = 1, 
             return(lapply(seq(m), function(x) temp.data))
         }
     }
+
+    dat.colnames <- NULL
     if(method != "hot deck")
     {
         # CE-437: Integer and numeric columns created by calling unclass() on factors contain levels,
         # which confuses mice and causes it to crash (and display cryptic warnings).
         data <- removeLevelsFromNumericData(data)
 
-        dat.colnames <- NULL
+
         imputed.data <- suppressWarnings(try(
             {
                 # Require is used instead of Depends because using Depends

--- a/R/imputation.R
+++ b/R/imputation.R
@@ -20,6 +20,7 @@
 #' @export
 Imputation <- function(data = NULL, formula = NULL, method = "try mice", m = 1, seed = 12321)
 {
+    method <- tolower(method)
     .errorInImputation <- function(imputed.data, formula)
     {
         if (any("try-error" %in% class(imputed.data)))
@@ -47,7 +48,7 @@ Imputation <- function(data = NULL, formula = NULL, method = "try mice", m = 1, 
             return(lapply(seq(m), function(x) temp.data))
         }
     }
-    if(method != "Hot deck")
+    if(method != "hot deck")
     {
         # CE-437: Integer and numeric columns created by calling unclass() on factors contain levels,
         # which confuses mice and causes it to crash (and display cryptic warnings).

--- a/R/imputation.R
+++ b/R/imputation.R
@@ -14,6 +14,9 @@
 #' Skyler J. Cranmer and Jeff Gill (2013). We Have to Be Discrete About This: A Non-Parametric Imputation Technique for Missing Categorical Data. British Journal of Political Science, 43, pp 425-449.
 #' Stef van Buuren and Karin Groothuis-Oudshoorn (2011), "mice: Multivariate
 #' Imputation by Chained Equations in R", Journal of Statistical Software, 45:3, 1-67.
+#' @details Variables with class \code{"POSIXct"} are converted to numeric and
+#' scaled prior to imputation. Variables with class \code{"character"} are converted
+#' to factor prior to imputation with blank (0-character) entries considered missing.
 #' @importFrom mice mice complete
 #' @importFrom flipU OutcomeName CopyAttributes AnyNA AllVariablesNames
 #' @importFrom hot.deck hot.deck
@@ -26,7 +29,7 @@ Imputation <- function(data = NULL, formula = NULL, method = "try mice", m = 1, 
         if (any("try-error" %in% class(imputed.data)))
             return(TRUE)
         for (i.data in imputed.data){
-            if(AnyNA(i.data, formula))
+            if(anyNA(i.data))
                 return(TRUE)
         }
         FALSE
@@ -49,14 +52,10 @@ Imputation <- function(data = NULL, formula = NULL, method = "try mice", m = 1, 
         }
     }
 
-    dat.colnames <- NULL
+    pdata <- preProcessData(data)
+    hot.deck.used <- FALSE
     if(method != "hot deck")
     {
-        # CE-437: Integer and numeric columns created by calling unclass() on factors contain levels,
-        # which confuses mice and causes it to crash (and display cryptic warnings).
-        data <- removeLevelsFromNumericData(data)
-
-
         imputed.data <- suppressWarnings(try(
             {
                 # Require is used instead of Depends because using Depends
@@ -66,26 +65,14 @@ Imputation <- function(data = NULL, formula = NULL, method = "try mice", m = 1, 
                 # dependencies is very deep
                 require("mice")
                 set.seed(seed)
-                dat.colnames <- colnames(data)
-                colnames(data) <- paste0("A", 1:ncol(data)) # need to replace names to avoid errors in mice v3.0.0
-                mice.setup <- if (single.var)
-                                  mice(cbind(data, jrhtr46__ = 1), m = m, seed = seed,
-                                        method = c("sample", ""), printFlag = FALSE)
-                              else mice(data, m = m, seed = seed, printFlag = FALSE)
+                ## dat.colnames <- colnames(data)
+                ## colnames(data) <- paste0("A", 1:ncol(data)) # need to replace names to avoid errors in mice v3.0.0
+                mice.method <- if (single.var) c("sample", "")  # else NULL
+                mice.setup <- mice(pdata, m = m, seed = seed, printFlag = FALSE,
+                                   method = mice.method)
                 data.sets <- vector("list", m)
                 for (i in 1:m)
-                {
-                    dat.i <- if (single.var)
-                                 CopyAttributes(complete(mice.setup,
-                                                         action = i)[, 1, drop = FALSE], data)
-                             else
-                                 CopyAttributes(complete(mice.setup, action = i), data,
-                                       attr.to.not.copy = NULL)
-                    attr(dat.i, "imputation.method") <- "chained equations (predictive mean matching)"
-                    colnames(dat.i) <- dat.colnames
-                    data.sets[[i]] <- dat.i
-                }
-                colnames(data) <- dat.colnames
+                    data.sets[[i]] <- complete(mice.setup, action = i)
                 data.sets
             }
         , silent = TRUE))
@@ -95,22 +82,20 @@ Imputation <- function(data = NULL, formula = NULL, method = "try mice", m = 1, 
     if (method != "mice" && (method == "hot deck" || .errorInImputation(imputed.data, formula)))
     {
         set.seed(seed)
-        if (!is.null(dat.colnames))
-            colnames(data) <- dat.colnames
-        imputed.data <- if (single.var)
-                            suppressWarnings(hot.deck(cbind(data, xytr745___ = 1L),
-                                                      m = m)$data)
-                        else
-                            suppressWarnings(hot.deck(data, m = m)$data)
-        for (i in 1:m)
-        {
-            attr(imputed.data[[i]], "imputation.method") <- "hot decking"
-            if (single.var)
-                imputed.data[[i]] <- imputed.data[[i]][, 1, drop = FALSE]
-        }
+        imputed.data <- suppressWarnings(hot.deck(pdata, m = m)$data)
+        all.na.rows <- nrow(imputed.data[[1]]) != nrow(data)
+        hot.deck.used <- TRUE
     }
     if (.errorInImputation(imputed.data, formula))
         stop("Imputation has failed.")
+
+    imputation.method <- ifelse(hot.deck.used, "hot decking",
+                                "chained equations (predictive mean matching)")
+    for (i in 1:m)
+    {
+        imputed.data[[i]] <- postProcessData(pdata, imputed.data[[i]], data)
+        attr(imputed.data[[i]], "imputation.method") <- imputation.method
+    }
     if (!is.null(formula))
     {
         if (!is.null(outcome.name))
@@ -128,13 +113,87 @@ Imputation <- function(data = NULL, formula = NULL, method = "try mice", m = 1, 
     imputed.data
 }
 
-removeLevelsFromNumericData <- function(data)
+#' 1) CE-437: Drops levels from integer and numeric columns created by
+#' calling unclass() on factors contain levels, which confuses mice
+#' and causes it to crash (and display cryptic warnings).
+#' 2) Converts date variables to numeric
+#' 3) relabels factors with duplicate levels so they are unique
+#' 4) Converts text variables to factors with blank entries converted to NA
+#' @noRd
+preProcessData <- function(data)
 {
+    orig.classes <- lapply(data, class)
+    ## orig.attrs <- lapply(data, attributes)
     for (nms in names(data))
     {
         clss <- class(data[[nms]])
-        if (clss == "integer" ||  clss == "numeric")
+        if (any(c("integer", "numeric") %in% clss))
             attr(data[[nms]], "levels") <- NULL
+        else if ("character" %in% clss)
+            data[[nms]] <- factor(data[[nms]], exclude = c("", NA))
+        else if ("factor" %in% clss)
+            levels(data[[nms]]) <- make.unique(levels(data[[nms]]))
+        else if (inherits(data[[nms]], c("QDate", "POSIXlt", "POSIXct")))
+            data[[nms]] <- as.numeric(data[[nms]])/1e9
     }
-    data
+    ## add dummy extra variable to allow mice/hotdeck to run with a single variable
+    if (NCOL(data) == 1L)
+        data <- cbind(data, DUMMY__VAR__ = 1)
+    ## need to replace names to avoid errors in mice v3.0.0
+    attr(data, "orig.names") <- colnames(data)
+    colnames(data) <- paste0("A", 1:ncol(data))
+    return(data)
+}
+
+#' Converts text and date variables back to their original types
+#' Converts de-duplicated factor levels back to their original state
+#' @noRd
+postProcessData <- function(preprocessed.data, imputed.data, orig.data)
+{
+    ## orig.classes <- preprocessed.data[["orig.classes"]]
+    ## orig.attrs <- preprocessed.data[["orig.attrs"]]
+    colnames(imputed.data) <- colnames(orig.data)
+    orig.classes <- lapply(orig.data, class)
+    if (NCOL(orig.data) == 1)  # drop dummy variable needed to run mice with 1 var.
+        imputed.data <- imputed.data[, 1, drop = FALSE]
+    if (nrow(imputed.data) != nrow(orig.data))
+        imputed.data <- imputeAllMissingRows(imputed.data, preprocessed.data)
+    for (nms in colnames(imputed.data))
+    {
+        orig.class <- orig.classes[[nms]]
+        if ("character" %in% orig.class)
+            imputed.data[[nms]] <- as.character(imputed.data[[nms]])
+        else if ("factor" %in% orig.class)  # preserve duplicate levels to match Displayr
+            imputed.data[[nms]] <- structure(as.integer(imputed.data[[nms]]),
+                                             .Label = levels(orig.data[[nms]]),
+                                             class = class(orig.data[[nms]]))
+        else if (any(orig.class %in% c("QDate", "POSIXct")))
+        {
+            imputed.data[[nms]] <- as.POSIXct(1e9*imputed.data[[nms]],
+                                             origin = "1970-01-01")
+            class(imputed.data[[nms]]) <- c(class(imputed.data[[nms]]), "QDate")
+        }
+    }
+    imputed.data <- CopyAttributes(imputed.data, orig.data,
+                                   attr.to.not.copy = c("dimnames", "names", "dim", "class", "levels"))
+    ## colnames(imputed.data) <- attr(preprocessed.data, "orig.names")
+    return(imputed.data)
+}
+
+#' The hot deck method drops rows from the data that are entirely missing. This
+#' function uses mice to impute values for rows with entirely missing data by
+#' randomly sampling the observed values
+imputeAllMissingRows <- function(imputed.data, processed.data, seed = 585)
+{
+    out.dat <- processed.data
+    all.na.rows <- which(apply(processed.data, 1, function(x) all(is.na(x))))
+    out.dat[-all.na.rows, ] <- imputed.data
+    mice.method <- rep("sample", ncol(out.dat))
+    try(
+    {
+        mice.out <- mice(out.dat, m = 1, seed = seed, printFlag = FALSE,
+                         method = mice.method)
+        out.dat <- complete(mice.out, action = 1)
+    }, TRUE)
+    return(out.dat)
 }

--- a/man/Imputation.Rd
+++ b/man/Imputation.Rd
@@ -4,8 +4,13 @@
 \alias{Imputation}
 \title{\code{Imputation}}
 \usage{
-Imputation(data = NULL, formula = NULL, method = "try mice", m = 1,
-  seed = 12321)
+Imputation(
+  data = NULL,
+  formula = NULL,
+  method = "try mice",
+  m = 1,
+  seed = 12321
+)
 }
 \arguments{
 \item{data}{A \code{\link{data.frame}}.}
@@ -24,6 +29,11 @@ occurs, falls back to \code{\link[hot.deck]{hot.deck}}.}
 }
 \description{
 This is a wrapper for \code{\link{mice}}.
+}
+\details{
+Variables with class \code{"POSIXct"} are converted to numeric and
+scaled prior to imputation. Variables with class \code{"character"} are converted
+to factor prior to imputation with blank (0-character) entries considered missing.
 }
 \references{
 von Hippel, Paul T. 2007. "Regression With Missing Y's: An

--- a/tests/testthat/test-imputation.R
+++ b/tests/testthat/test-imputation.R
@@ -1036,7 +1036,7 @@ test_that("Imputation with a single variable",
     expect_equal(sort(na.omit(unique(num))[]),
                  sort(unique(out[[1]][, 1])))
 
-    out <- Imputation(data.frame(x = fac), method = "mice", m = 2)
+    out <- Imputation(data.frame(x = fac), method = "mice", m = 1)
     expect_false(anyNA(out[[2L]]))
     ## mice samples existing values to get imputed values
     expect_equal(sort(na.omit(unique(fac))[]),
@@ -1046,6 +1046,6 @@ test_that("Imputation with a single variable",
     out <- Imputation(data.frame(x = num), method = "hot deck", m = 1)
     expect_false(anyNA(out[[1L]]))
 
-    out <- Imputation(data.frame(x = fac), method = "hot deck", m = 1)
+    out <- Imputation(data.frame(x = fac), method = "hot deck", m = 2)
     expect_false(anyNA(out[[1L]]))
 })

--- a/tests/testthat/test-imputation.R
+++ b/tests/testthat/test-imputation.R
@@ -1049,3 +1049,94 @@ test_that("Imputation with a single variable",
     out <- Imputation(data.frame(x = fac), method = "hot deck", m = 2)
     expect_false(anyNA(out[[1L]]))
 })
+
+test_that("Imputation works with date variables",
+{
+    dat.var <- structure(c(1504742400, 1481760000, 1435795200, 1477526400, 1497484800,
+    1456358400, 1482364800, 1438819200, 1449100800, 1437004800, 1481760000,
+    1513209600, 1493856000, 1462665600, 1439424000, 1446076800, 1444262400,
+    1464825600, 1494460800, 1485993600, 1478131200, 1449705600, 1463616000,
+    1483574400, 1461801600, 1461801600, 1484784000, 1501113600, 1495065600,
+    1479945600, 1446681600, 1501113600, 1457568000, 1483574400, 1498089600,
+    1476921600, 1437609600, 1447286400, 1453334400, 1469664000, 1487808000,
+    1504742400, 1449100800, 1506556800, 1437609600, 1452124800, 1442448000,
+    1449100800, 1446681600, 1487203200, 1476921600, 1510185600, 1508371200,
+    1437004800, 1447891200, 1481760000, 1442448000, 1458172800, 1485993600,
+    1440028800, 1437004800, 1438819200, 1467849600, 1455753600, 1457568000,
+    1443657600, 1500508800, 1500508800, 1481155200, 1492646400, 1451520000,
+    1508976000, 1454544000, 1476316800, 1441238400, 1480550400, 1489017600,
+    1447891200, 1458172800, 1446076800, 1500508800, 1496880000, 1444867200,
+    1487203200, 1450915200, 1496880000, 1473292800, 1502928000, 1452729600,
+    1496275200, 1496275200, 1448496000, 1440633600, 1452124800, 1455753600,
+    1446681600, 1506556800, 1458777600, 1487808000, 1440028800), class = c("POSIXct",
+    "POSIXt", "QDate"), QDate = structure(c(27L, 18L, 1L, 16L, 24L,
+    8L, 18L, 2L, 6L, 1L, 18L, 30L, 23L, 11L, 2L, 4L, 4L, 12L, 23L,
+    20L, 17L, 6L, 11L, 19L, 10L, 10L, 19L, 25L, 23L, 17L, 5L, 25L,
+    9L, 19L, 24L, 16L, 1L, 5L, 7L, 13L, 20L, 27L, 6L, 27L, 1L, 7L,
+    3L, 6L, 5L, 20L, 16L, 29L, 28L, 1L, 5L, 18L, 3L, 9L, 20L, 2L,
+    1L, 2L, 13L, 8L, 9L, 4L, 25L, 25L, 18L, 22L, 6L, 28L, 8L, 16L,
+    3L, 18L, 21L, 5L, 9L, 4L, 25L, 24L, 4L, 20L, 6L, 24L, 15L, 26L,
+    7L, 24L, 24L, 5L, 2L, 7L, 8L, 5L, 27L, 9L, 20L, 2L), class = c("ordered",
+    "factor"), .Label = c("July 2015", "August 2015", "September 2015",
+    "October 2015", "November 2015", "December 2015", "January 2016",
+    "February 2016", "March 2016", "April 2016", "May 2016", "June 2016",
+    "July 2016", "August 2016", "September 2016", "October 2016",
+    "November 2016", "December 2016", "January 2017", "February 2017",
+    "March 2017", "April 2017", "May 2017", "June 2017", "July 2017",
+    "August 2017", "September 2017", "October 2017", "November 2017",
+    "December 2017")), questiontype = "Date", dataset = "burger_subset",
+    codeframe = list(Date = 0L), name = "date", label = "Date", question = "Date")
+
+    set.seed(808)
+    dat <- data.frame(date = dat.var, x = as.factor(sample(3, length(dat.var), TRUE)),
+                      y = rnorm(length(dat.var)))
+    is.na(dat$date) <- c(2, 4, 6)
+    is.na(dat$x) <- 1:3
+    is.na(dat$y) <- 9:10
+    out <- Imputation(dat, m = 2)
+    expect_false(anyNA(out[[1]]))
+    expect_equal(colnames(out[[2]]), colnames(dat))
+    expect_is(out[[1]][, 1], "QDate")
+
+    out <- Imputation(dat, method = "hot deck")[[1L]]
+    expect_false(anyNA(out))
+    expect_equal(colnames(out), colnames(dat))
+    expect_is(out[, 1], "QDate")
+})
+
+test_that("Imputation still works if duplicate factor levels present",
+{
+    set.seed(333)
+    dat <- data.frame(x = rnorm(50), y = rnorm(50))
+    dat$z <- structure(c(4L, 2L, 2L, 2L, 3L, 2L, 2L, 3L, 2L, 1L, 3L, 1L, 1L,
+        3L, 1L, 3L, 1L, 1L, 4L, 3L, 4L, 1L, 1L, 4L, 2L, 4L, 2L, 2L, 3L,
+        2L, 1L, 1L, 1L, 2L, 2L, 3L, 4L, 2L, 2L, 1L, 2L, 1L, 3L, 4L, 2L,
+        1L, 1L, 1L, 1L, 2L), .Label = c("A", "B", "C", "A"), class = "factor")
+    is.na(dat) <- cbind(1:6, rep(1:3, each = 2))
+    out <- Imputation(dat)[[1L]]
+    expect_false(anyNA(out))
+    expect_equal(levels(out$z), levels(dat$z))
+})
+
+test_that("Imputation still works if duplicate factor levels present",
+{
+    set.seed(3335)
+    dat <- data.frame(x = rnorm(50), y = runif(50))
+    dat$z <- sample(c("", letters[1:4]), 50, TRUE)
+    is.na(dat) <- cbind(6:1, rep(1:3, each = 2))
+    out <- Imputation(dat, m = 2)[[2L]]
+    expect_false(anyNA(out))
+    expect_is(out$z, "character")
+    expect_equal(sort(unique(out$z)), letters[1:4])  # no ""
+})
+
+test_that("Method hot deck imputes all NA rows",
+{
+    set.seed(234)
+    dat <- data.frame(x = runif(100, -1, 1), y = rnorm(100))
+    dat[5:6, ] <- NA
+    dat[7, 1] <- NA
+    out <- Imputation(dat, method = "hot deck")[[1L]]
+    expect_false(anyNA(out))
+    expect_equal(dim(out), dim(dat))
+})

--- a/tests/testthat/test-imputation.R
+++ b/tests/testthat/test-imputation.R
@@ -1037,7 +1037,7 @@ test_that("Imputation with a single variable",
                  sort(unique(out[[1]][, 1])))
 
     out <- Imputation(data.frame(x = fac), method = "mice", m = 1)
-    expect_false(anyNA(out[[2L]]))
+    expect_false(anyNA(out[[1L]]))
     ## mice samples existing values to get imputed values
     expect_equal(sort(na.omit(unique(fac))[]),
                  sort(unique(out[[1]][, 1])))

--- a/tests/testthat/test-imputation.R
+++ b/tests/testthat/test-imputation.R
@@ -1023,3 +1023,29 @@ test_that("No imputation needed",
     expect_equal(z[[1]], seq(100))
 })
 
+test_that("Imputation with a single variable",
+{
+    num <- 1:100
+    num[1:3] <- NA
+    fac <- as.factor(sample(3, 100, replace = TRUE))
+    is.na(fac) <- 3:5
+
+    out <- Imputation(data.frame(x = num), method = "mice", m = 2)
+    expect_false(anyNA(out[[2L]]))
+    ## mice samples existing values to get imputed values
+    expect_equal(sort(na.omit(unique(num))[]),
+                 sort(unique(out[[1]][, 1])))
+
+    out <- Imputation(data.frame(x = fac), method = "mice", m = 2)
+    expect_false(anyNA(out[[2L]]))
+    ## mice samples existing values to get imputed values
+    expect_equal(sort(na.omit(unique(fac))[]),
+                 sort(unique(out[[1]][, 1])))
+
+
+    out <- Imputation(data.frame(x = num), method = "hot deck", m = 1)
+    expect_false(anyNA(out[[1L]]))
+
+    out <- Imputation(data.frame(x = fac), method = "hot deck", m = 1)
+    expect_false(anyNA(out[[1L]]))
+})


### PR DESCRIPTION
* Convert POSIXct/QDate variables to numeric before imputation
* Convert text variables to factors before imputing, ensure blank
strings are set to NA
* Categorical variables in Displayr can contain duplicate levels
which cause an error in mice, make the levels unique before imputation
* Method hot deck drops all NA rows from the output data set, added
new function to use mice to randomly impute the values for rows with
all missing values after hot deck imputation (needed to ensure created
R variable always has the right length in Displayr)
* Allow a single variable to be imputed with random values