### PR TITLE
DPI-2857 Package flipImputation in nix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,13 @@
+{ pkgs ? import <nixpkgs> {}, displayrUtils }:
+
+pkgs.rPackages.buildRPackage {
+  name = "flipImputation";
+  version = displayrUtils.extractRVersion (builtins.readFile ./DESCRIPTION); 
+  src = ./.;
+  description = "Functions for imputing data using mice and hot.deck.";
+  propagatedBuildInputs = with pkgs.rPackages; [ 
+    hot_deck
+    mice
+    flipU
+  ];
+}


### PR DESCRIPTION
As part of the R Server CI/CD uplift, this task is to package flipImputation in Nix to make R server CI/CD more reliable and reproducible. To build it, see https://github.com/Displayr/NixR